### PR TITLE
Updating style to spaces

### DIFF
--- a/src/components/organisms/carrers/CareerBase.jsx
+++ b/src/components/organisms/carrers/CareerBase.jsx
@@ -31,6 +31,8 @@ const CareerBase = ({ title, text, image, reverse, subtitle, imageClass }) => {
                 textAlign: "justify",
                 textJustify: "inter-word",
                 maxWidth: "520",
+                lineHeight: "30px",
+                paddingTop: "15px",
               }}
             >
               {text}


### PR DESCRIPTION
This PR contains fix to:
Bug25: Los textos de las imagenes del body de los tabs 'Company', 'Services', 'Carrers'  no tienes espaciado entre líneas